### PR TITLE
PHP 5.4 fixes

### DIFF
--- a/mod_forumng.php
+++ b/mod_forumng.php
@@ -1879,6 +1879,11 @@ WHERE
      */
     public function get_subscription_info($userid=0, $expectingquery=false) {
         global $DB, $FORUMNG_CACHE;
+
+        if(!is_object($FORUMNG_CACHE)){
+            $FORUMNG_CACHE = new stdclass();
+        }
+
         $userid = mod_forumng_utils::get_real_userid($userid);
 
         if (!isset($FORUMNG_CACHE)) {


### PR DESCRIPTION
Declare $FORUMNG_CACHE as new stdclass if it isn't an object yet.
