### PR TITLE
Fix unread discussions count (on course front page)

### DIFF
--- a/mod_forumng.php
+++ b/mod_forumng.php
@@ -745,7 +745,14 @@ WHERE
      */
     public function get_num_unread_discussions() {
         if (!isset($this->forumfields->numunreaddiscussions)) {
-            throw new coding_exception('Unread discussion count not obtained');
+            //throw new coding_exception('Unread discussion count not obtained');
+            $list = $this->get_discussion_list();
+            $normal = $list->get_normal_discussions();
+            $discussioncount = 0;
+            foreach ($normal as $discussion) {
+                $discussioncount += $discussion->get_num_unread_posts();
+            }
+            return $discussioncount;
         }
         return $this->forumfields->numunreaddiscussions;
     }


### PR DESCRIPTION
Translated token "hasunreadposts" used to show the unread discussion count, but not anymore.

While adding the "unread discussion count" as a parameter to the token, I noticed forumfields->numunreaddiscussions does not properly hold the actual number of discussions that has new posts in them.

So here is a suggested fix for get_num_unread_discussions() which does not seem to work properly when using it to view unread (post) discussions on the course front page. 

I use it together with:
get_string('hasunreadposts', 'forumng', $forums[$cm->instance]->get_num_unread_discussions());

$string['hasunreadposts'] = '({$a} Unread posts)';

What do you think?
