### PR TITLE
Change require to require_once to stop unit tests crashing

### DIFF
--- a/tests/forumlistapi_test.php
+++ b/tests/forumlistapi_test.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require($CFG->dirroot . '/mod/forumng/externallib.php');
-require($CFG->dirroot . '/course/lib.php');
+require_once($CFG->dirroot . '/course/lib.php');
 
 /**
  * PHPUnit forum list api testcase.


### PR DESCRIPTION
When running the full unit test suite on a Moodle install with forumng in it, we are getting a fatal error:

> PHP Fatal error:  Cannot redeclare make_log_url() (previously declared in /var/www/jyhoam-test/course/lib.php:61) in /var/www/jyhoam-test/course/lib.php on line 142

This is because forumng is trying to include /course/lib.php for a second time. If we change the "require" to a "require_once" it fixes the problem.

Cheers

Michael
