### PR TITLE
Fixes PHP8 deprecation warning

### DIFF
--- a/advancedsearch.php
+++ b/advancedsearch.php
@@ -288,8 +288,8 @@ if ($data) {
             $results = forumng_get_results_for_all_forums($course, $author,
                     $data->datefrom, $data->dateto, $page, !empty($data->asmoderator));
         } else {
-            $results = forumng_get_results_for_this_forum($forum, $groupid, $author,
-                    $data->datefrom, $data->dateto, $page, !empty($data->asmoderator));
+            $results = forumng_get_results_for_this_forum($forum, $page, $groupid,
+                $author, $data->datefrom, $data->dateto, !empty($data->asmoderator));
         }
         $nextpage = $page + FORUMNG_SEARCH_RESULTSPERPAGE;
 

--- a/advancedsearchlib.php
+++ b/advancedsearchlib.php
@@ -63,16 +63,16 @@ function forumng_exclude_words_filter($result) {
 /**
  * Get search results.
  * @param object $forum
+ * @param int $page
  * @param int $groupid
  * @param string $author
  * @param int $daterangefrom
  * @param int $daterangeto
- * @param int $page
  * @param int $resultsperpage (FORUMNG_SEARCH_RESULTSPERPAGE used as constant)
  * @return object
  */
-function forumng_get_results_for_this_forum($forum, $groupid, $author=null, $daterangefrom=0,
-        $daterangeto=0, $page, $asmoderator = false, $resultsperpage=FORUMNG_SEARCH_RESULTSPERPAGE) {
+function forumng_get_results_for_this_forum($forum, $page, $groupid, $author=null,
+        $daterangefrom=0, $daterangeto=0, $asmoderator = false, $resultsperpage=FORUMNG_SEARCH_RESULTSPERPAGE) {
 
     $before = microtime(true);
 

--- a/atomlib.php
+++ b/atomlib.php
@@ -46,24 +46,24 @@ function atom_standard_header($uniqueid, $link, $updated, $title = null, $descri
 
         // Open the channel
         // write channel info.
-        $result .= atom_full_tag('id', 1, false, htmlspecialchars($uniqueid));
-        $result .= atom_full_tag('updated', 1, false, date_format_rfc3339($updated));
-        $result .= atom_full_tag('title', 1, false, htmlspecialchars(html_to_text($title)));
-        $result .= atom_full_tag('link', 1, false, null, array('href'=>$link, 'rel'=>'self'));
+        $result .= atom_full_tag('id', htmlspecialchars($uniqueid), 1, false);
+        $result .= atom_full_tag('updated', date_format_rfc3339($updated), 1, false);
+        $result .= atom_full_tag('title', htmlspecialchars(html_to_text($title)), 1, false);
+        $result .= atom_full_tag('link', null, 1, false, array('href' => $link, 'rel' => 'self'));
         if (!empty($description)) {
-            $result .= atom_full_tag('subtitle', 1, false, $description);
+            $result .= atom_full_tag('subtitle', $description, 1, false);
         }
-        $result .= atom_full_tag('generator', 1, false, 'Moodle');
+        $result .= atom_full_tag('generator', 'Moodle', 1, false);
         $today = getdate();
-        $result .= atom_full_tag('rights', 1, false, '&#169; '. $today['year'] .' '.
-                format_string($site->fullname));
+        $result .= atom_full_tag('rights', '&#169; ' . $today['year'] . ' ' .
+            format_string($site->fullname), 1, false);
 
         // Write image info.
         $out = mod_forumng_utils::get_renderer();
         $atompix = $out->image_url('/i/rsssitelogo');
 
         // Write the info.
-        $result .= atom_full_tag('logo', 1, false, $atompix);
+        $result .= atom_full_tag('logo', $atompix, 1, false);
 
     }
 
@@ -85,21 +85,21 @@ function atom_add_items($items) {
     if (!empty($items)) {
         foreach ($items as $item) {
             $result .= atom_start_tag('entry', 1, true);
-            $result .= atom_full_tag('title', 2, false,
-                    htmlspecialchars(html_to_text($item->title)));
-            $result .= atom_full_tag('link', 2, false, null,
-                    array('href' => $item->link, 'rel'=>'alternate'));
-            $result .= atom_full_tag('updated', 2, false, date_format_rfc3339($item->pubdate));
+            $result .= atom_full_tag('title', htmlspecialchars(html_to_text($item->title)), 2,
+                false);
+            $result .= atom_full_tag('link', null, 2, false,
+                array('href' => $item->link, 'rel' => 'alternate'));
+            $result .= atom_full_tag('updated', date_format_rfc3339($item->pubdate), 2, false);
             // Include the author if exists.
             if (isset($item->author)) {
                 $result .= atom_start_tag('author', 2, true);
-                $result .= atom_full_tag('name', 3, false, $item->author);
+                $result .= atom_full_tag('name', $item->author, 3, false);
                 $result .= atom_end_tag('author', 2, true);
             }
-            $result .= atom_full_tag('content', 2, false,
-                    '<div xmlns="http://www.w3.org/1999/xhtml">'.clean_text($item->description,
-                    FORMAT_HTML).'</div>', $xhtmlattr);
-            $result .= atom_full_tag('id', 2, false, htmlspecialchars($item->link));
+            $result .= atom_full_tag('content', '<div xmlns="http://www.w3.org/1999/xhtml">' . clean_text($item->description,
+                    FORMAT_HTML) . '</div>', 2,
+                false, $xhtmlattr);
+            $result .= atom_full_tag('id', htmlspecialchars($item->link), 2, false);
             if (isset($item->tags)) {
                 $tagdata = array();
                 if (isset($item->tagscheme)) {
@@ -107,7 +107,7 @@ function atom_add_items($items) {
                 }
                 foreach ($item->tags as $tag) {
                     $tagdata['term'] = $tag;
-                    $result .= atom_full_tag('category', 2, true, false, $tagdata);
+                    $result .= atom_full_tag('category', false, 2, true, $tagdata);
                 }
             }
             $result .= atom_end_tag('entry', 1, true);
@@ -164,7 +164,7 @@ function atom_end_tag($tag, $level=0, $endline=true) {
 
 
 // Return the start tag, the contents and the end tag.
-function atom_full_tag($tag, $level=0, $endline=true, $content, $attributes=null) {
+function atom_full_tag($tag, $content, $level=0, $endline=true, $attributes=null) {
     global $CFG;
     $st = atom_start_tag($tag, $level, $endline, $attributes);
     if ($content === false) {

--- a/mod_forumng.php
+++ b/mod_forumng.php
@@ -3132,8 +3132,8 @@ WHERE
             }
         }
 
-        $rows = self::query_forums($specificids, $course, $userid,
-            $unread, $groups, $aagforums, $viewhiddenforums);
+        $rows = self::query_forums($userid, $unread, $groups,
+            $aagforums, $viewhiddenforums, $specificids, $course);
         foreach ($rows as $rec) {
             // Check course-module exists
             if (!array_key_exists($rec->cm_id, $modinfo->cms)) {
@@ -3211,21 +3211,21 @@ WHERE
     /**
      * Internal method. Queries for a number of forums, including additional
      * data about unread posts etc. Returns the database result.
-     * @param array $cmids If specified, array of course-module IDs of desired
-     *   forums
-     * @param object $course If specified, course object
      * @param int $userid User ID, 0 = current user
+     *   forums
      * @param int $unread Type of unread data to obtain (UNREAD_xx constant).
      * @param array $groups Array of group IDs to which the given user belongs
-     *   (may be null if unread data not required)
      * @param array $aagforums Array of forums in which the user has
-     *   'access all groups' (may be null if unread data not required)
      * @param array $viewhiddenforums Array of forums in which the user has
+     *   (may be null if unread data not required)
+     * @param array $cmids If specified, array of course-module IDs of desired
+     *   'access all groups' (may be null if unread data not required)
+     * @param object $course If specified, course object
      *   'view hidden discussions' (may be null if unread data not required)
      * @return array Array of row objects
      */
-    private static function query_forums($cmids=array(), $course=null,
-            $userid, $unread, $groups, $aagforums, $viewhiddenforums) {
+    private static function query_forums($userid, $unread,
+            $groups, $aagforums, $viewhiddenforums, $cmids=array(), $course=null) {
         global $DB, $CFG, $USER;
         if ((!count($cmids) && !$course)) {
             throw new coding_exception("mod_forumng::query_forums requires course id or cmids");
@@ -3297,8 +3297,8 @@ WHERE
                         if (forumngtype::get_new($type)->has_unread_restriction()) {
                             // This one's a problem! Do it individually
                             $problemresults = self::query_forums(
-                                array($info->id), null, $userid, $unread,
-                                $groups, $aagforums, $viewhiddenforums);
+                                $userid, $unread, $groups, $aagforums,
+                                $viewhiddenforums, array($info->id), null);
                             foreach ($problemresults as $problemresult) {
                                 $plusresult[$problemresult->f_id] = $problemresult;
                             }
@@ -5302,8 +5302,8 @@ WHERE
             $viewhiddenforums[] = $DB->get_field(
                     'course_modules', 'instance', array('id' => $cmid));
         }
-        $rows = self::query_forums(array($cmid), null, $userid, $unread,
-                array(), array(), $viewhiddenforums);
+        $rows = self::query_forums($userid, $unread, array(), array(),
+            $viewhiddenforums, array($cmid), null);
         if (count($rows) != 1) {
             throw new coding_exception('Unexpected data extracting base forum');
         }

--- a/pluginfile.php
+++ b/pluginfile.php
@@ -31,7 +31,7 @@ $relativepath = get_file_argument();
 // Relative path must start with '/'.
 if (!$relativepath) {
     print_error('invalidargorconf');
-} else if ($relativepath{0} != '/') {
+} else if ($relativepath[0] != '/') {
     print_error('pathdoesnotstartslash');
 }
 


### PR DESCRIPTION
Fixes PHP8 deprecation warning, see -> https://php.watch/versions/8.0/deprecate-required-param-after-optional
Fixes deprecated curly brace syntax for accessing array elements